### PR TITLE
Try adding missing pkgconf for pkg-config to mingw image

### DIFF
--- a/0.3.0/mingw/Dockerfile
+++ b/0.3.0/mingw/Dockerfile
@@ -80,6 +80,7 @@ RUN pikaur -S --noconfirm --noprogressbar \
         mingw-w64-tools \
         mingw-w64-winpthreads \
         mingw-w64-zlib \
+        pkgconf \
     && (echo -e "y\ny\n" | sudo pacman -Scc)
 
 USER root


### PR DESCRIPTION
Logs in https://github.com/OpenRCT2/OpenRCT2/pull/12792 suggest it is required, even though mingw variant is already present:
```
 CMake Error at /usr/share/cmake-3.18/Modules/FindPkgConfig.cmake:601 (message):
  pkg-config tool not found
Call Stack (most recent call first):
  /usr/share/cmake-3.18/Modules/FindPkgConfig.cmake:733 (_pkg_check_modules_internal)
  src/openrct2-ui/CMakeLists.txt:16 (PKG_CHECK_MODULES)
  CMakeLists.txt:286 (include)
```