### PR TITLE
Fix outdated nlohmann-json library

### DIFF
--- a/0.3.0/bionic/Dockerfile
+++ b/0.3.0/bionic/Dockerfile
@@ -12,13 +12,16 @@ RUN apt-get update && \
     libsdl2-dev libspeex-dev libspeexdsp-dev \
     libcrypto++-dev libcurl4-openssl-dev libssl-dev \
     libfontconfig1-dev libfreetype6-dev \
-    libicu-dev nlohmann-json-dev libpng-dev libzip-dev \
+    libicu-dev libpng-dev libzip-dev \
     duktape-dev \
   # Testing libraries
     libgtest-dev && \
   # Create symbolic links
     ln -s /usr/bin/clang-5.0 /usr/bin/clang && \
     ln -s /usr/bin/clang++-5.0 /usr/bin/clang++
+
+RUN mkdir /usr/include/nlohmann && \
+	curl https://github.com/nlohmann/json/releases/download/v3.9.1/json.hpp -Lo /usr/include/nlohmann/json.hpp
 
 # Bash is required for OpenRCT2 CI
 SHELL ["/bin/bash", "-c"]

--- a/0.3.0/bionic32/Dockerfile
+++ b/0.3.0/bionic32/Dockerfile
@@ -17,8 +17,11 @@ RUN    dpkg --add-architecture i386 \
          libsdl2-dev:i386 libspeex-dev:i386 libspeexdsp-dev:i386 \
          libcrypto++-dev:i386 libcurl4-openssl-dev:i386 libssl-dev:i386 \
          libfontconfig1-dev:i386 libfreetype6-dev:i386 \
-         nlohmann-json-dev libpng-dev:i386 libzip-dev:i386 libicu-dev:i386 \
+         libpng-dev:i386 libzip-dev:i386 libicu-dev:i386 \
          duktape-dev:i386
+
+RUN mkdir /usr/include/nlohmann && \
+	curl https://github.com/nlohmann/json/releases/download/v3.9.1/json.hpp -Lo /usr/include/nlohmann/json.hpp
 
 # Bash is required for OpenRCT2 CI
 SHELL ["/bin/bash", "-c"]


### PR DESCRIPTION
In the bionic builds, the [nlohmann-json-dev](https://packages.ubuntu.com/bionic/nlohmann-json-dev) library is not being updated by the apt-get package manager and is outdated (currently v2.1.1-1.1). Changed to download the header file directly from the nlohmann/json GH repo.