### PR TITLE
Change docker images to download full release of nlohmann json

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        tag: [0.3.0-android, 0.3.0-bionic, 0.3.0-bionic32, 0.3.0-format, 0.3.0-mingw]
+        tag: [0.3.1-android, 0.3.1-bionic, 0.3.1-bionic32, 0.3.1-format, 0.3.1-mingw]
     env:
       dockertag: ${{ matrix.tag }}
     steps:
@@ -37,10 +37,10 @@ jobs:
         run: |
           if [ "$dockerid" != "" ]; then
               docker login -u "$dockerid" -p "$dockerpass"
-              docker pull openrct2/openrct2-build:0.3.0-bionic
-              docker tag openrct2/openrct2-build:0.3.0-bionic openrct2/openrct2-build:0.3.0
-              docker tag openrct2/openrct2-build:0.3.0-bionic openrct2/openrct2-build:latest
-              docker push openrct2/openrct2-build:0.3.0
+              docker pull openrct2/openrct2-build:0.3.1-bionic
+              docker tag openrct2/openrct2-build:0.3.1-bionic openrct2/openrct2-build:0.3.1
+              docker tag openrct2/openrct2-build:0.3.1-bionic openrct2/openrct2-build:latest
+              docker push openrct2/openrct2-build:0.3.1
               docker push openrct2/openrct2-build:latest
           else
               echo 'Images not tagged'

--- a/0.3.1/android/Dockerfile
+++ b/0.3.1/android/Dockerfile
@@ -1,0 +1,46 @@
+# Default image that can build OpenRCT2 for Android.
+FROM ubuntu:18.04
+RUN apt-get update && \
+    apt-get -y upgrade && \
+    apt-get install --no-install-recommends -y \
+  # System
+    ca-certificates curl unzip \
+  # Build tools
+    git cmake pkg-config ninja-build ccache g++ \
+  # Build libraries
+    libsdl2-dev libspeex-dev libspeexdsp-dev \
+    libcrypto++-dev libcurl4-openssl-dev libssl-dev \
+    libfontconfig1-dev libfreetype6-dev \
+    libicu-dev libjansson-dev libpng-dev libzip-dev
+
+# Get JDK
+RUN apt-get -y install openjdk-8-jdk
+
+ENV ANDROID_HOME=/android-dev
+ENV ANDROID_NDK_HOME="$ANDROID_HOME/ndk"
+ENV JAVA_HOME=/usr/lib/jvm/java-8-openjdk-amd64
+
+# Grab the Android SDK
+WORKDIR /tmp/setup
+RUN curl -Lo sdk.zip https://dl.google.com/android/repository/sdk-tools-linux-4333796.zip \
+ && unzip -qo sdk.zip \
+ && mkdir $ANDROID_HOME \
+ && mv tools $ANDROID_HOME
+
+# Grab the Android NDK
+RUN curl -Lo ndk.zip https://dl.google.com/android/repository/android-ndk-r18b-linux-x86_64.zip \
+ && unzip -qo ndk.zip \
+ && mv android-ndk-* "$ANDROID_NDK_HOME"
+
+# Clean up
+RUN rm -rf /tmp/setup
+WORKDIR /
+
+RUN mkdir /nlohmann \
+ && curl https://github.com/nlohmann/json/releases/download/v3.9.1/json.hpp -Lo /nlohmann/json.hpp
+
+# Accept SDK licenses
+RUN yes | "$ANDROID_HOME/tools/bin/sdkmanager" --licenses > /dev/null
+
+# Bash is required for OpenRCT2 CI
+SHELL ["/bin/bash", "-c"]

--- a/0.3.1/android/Dockerfile
+++ b/0.3.1/android/Dockerfile
@@ -36,8 +36,8 @@ RUN curl -Lo ndk.zip https://dl.google.com/android/repository/android-ndk-r18b-l
 RUN rm -rf /tmp/setup
 WORKDIR /
 
-RUN mkdir /nlohmann \
- && curl https://github.com/nlohmann/json/releases/download/v3.9.1/json.hpp -Lo /nlohmann/json.hpp
+RUN	curl https://github.com/nlohmann/json/releases/download/v3.9.1/include.zip -Lo /usr/json.zip && \
+	unzip /usr/json.zip -d /usr/
 
 # Accept SDK licenses
 RUN yes | "$ANDROID_HOME/tools/bin/sdkmanager" --licenses > /dev/null

--- a/0.3.1/bionic/Dockerfile
+++ b/0.3.1/bionic/Dockerfile
@@ -1,0 +1,27 @@
+# Default image that can build OpenRCT2 for Linux (amd64).
+# Provides building with cmake+ninja using either gcc or clang.
+FROM ubuntu:18.04
+RUN apt-get update && \
+    apt-get -y upgrade && \
+    apt-get install --no-install-recommends -y \
+  # System
+    ca-certificates curl file libcairo2 patchelf \
+  # Build tools
+    git cmake pkg-config ninja-build ccache g++ clang-5.0 \
+  # Build libraries
+    libsdl2-dev libspeex-dev libspeexdsp-dev \
+    libcrypto++-dev libcurl4-openssl-dev libssl-dev \
+    libfontconfig1-dev libfreetype6-dev \
+    libicu-dev libpng-dev libzip-dev \
+    duktape-dev \
+  # Testing libraries
+    libgtest-dev && \
+  # Create symbolic links
+    ln -s /usr/bin/clang-5.0 /usr/bin/clang && \
+    ln -s /usr/bin/clang++-5.0 /usr/bin/clang++
+
+RUN mkdir /usr/include/nlohmann && \
+	curl https://github.com/nlohmann/json/releases/download/v3.9.1/json.hpp -Lo /usr/include/nlohmann/json.hpp
+
+# Bash is required for OpenRCT2 CI
+SHELL ["/bin/bash", "-c"]

--- a/0.3.1/bionic/Dockerfile
+++ b/0.3.1/bionic/Dockerfile
@@ -5,7 +5,7 @@ RUN apt-get update && \
     apt-get -y upgrade && \
     apt-get install --no-install-recommends -y \
   # System
-    ca-certificates curl file libcairo2 patchelf \
+    ca-certificates curl file libcairo2 patchelf unzip \
   # Build tools
     git cmake pkg-config ninja-build ccache g++ clang-5.0 \
   # Build libraries
@@ -20,8 +20,8 @@ RUN apt-get update && \
     ln -s /usr/bin/clang-5.0 /usr/bin/clang && \
     ln -s /usr/bin/clang++-5.0 /usr/bin/clang++
 
-RUN mkdir /usr/include/nlohmann && \
-	curl https://github.com/nlohmann/json/releases/download/v3.9.1/json.hpp -Lo /usr/include/nlohmann/json.hpp
+RUN	curl https://github.com/nlohmann/json/releases/download/v3.9.1/include.zip -Lo /usr/json.zip && \
+	unzip /usr/json.zip -d /usr/
 
 # Bash is required for OpenRCT2 CI
 SHELL ["/bin/bash", "-c"]

--- a/0.3.1/bionic32/Dockerfile
+++ b/0.3.1/bionic32/Dockerfile
@@ -1,0 +1,27 @@
+# Default image that can build OpenRCT2 for Linux (i686).
+# Provides building with cmake+ninja using gcc.
+FROM ubuntu:18.04
+RUN    dpkg --add-architecture i386 \
+    && apt-get update \
+    && apt-get install -y g++-7-multilib \
+    && update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-7 60 \
+    && apt-get update \
+    && apt-get -y upgrade \
+    && apt-get install --no-install-recommends -y \
+      # System
+         ca-certificates curl \
+      # Build tools
+         git cmake ninja-build ccache \
+         pkg-config:i386 \
+      # Build libraries
+         libsdl2-dev:i386 libspeex-dev:i386 libspeexdsp-dev:i386 \
+         libcrypto++-dev:i386 libcurl4-openssl-dev:i386 libssl-dev:i386 \
+         libfontconfig1-dev:i386 libfreetype6-dev:i386 \
+         libpng-dev:i386 libzip-dev:i386 libicu-dev:i386 \
+         duktape-dev:i386
+
+RUN mkdir /usr/include/nlohmann && \
+	curl https://github.com/nlohmann/json/releases/download/v3.9.1/json.hpp -Lo /usr/include/nlohmann/json.hpp
+
+# Bash is required for OpenRCT2 CI
+SHELL ["/bin/bash", "-c"]

--- a/0.3.1/bionic32/Dockerfile
+++ b/0.3.1/bionic32/Dockerfile
@@ -9,7 +9,7 @@ RUN    dpkg --add-architecture i386 \
     && apt-get -y upgrade \
     && apt-get install --no-install-recommends -y \
       # System
-         ca-certificates curl \
+         ca-certificates curl unzip \
       # Build tools
          git cmake ninja-build ccache \
          pkg-config:i386 \
@@ -20,8 +20,8 @@ RUN    dpkg --add-architecture i386 \
          libpng-dev:i386 libzip-dev:i386 libicu-dev:i386 \
          duktape-dev:i386
 
-RUN mkdir /usr/include/nlohmann && \
-	curl https://github.com/nlohmann/json/releases/download/v3.9.1/json.hpp -Lo /usr/include/nlohmann/json.hpp
+RUN	curl https://github.com/nlohmann/json/releases/download/v3.9.1/include.zip -Lo /usr/json.zip && \
+	unzip /usr/json.zip -d /usr/
 
 # Bash is required for OpenRCT2 CI
 SHELL ["/bin/bash", "-c"]

--- a/0.3.1/format/Dockerfile
+++ b/0.3.1/format/Dockerfile
@@ -1,0 +1,3 @@
+# Image specifically designed to run clang-format on OpenRCT2 source files.
+FROM alpine
+RUN apk add --no-cache clang python3

--- a/0.3.1/mingw/Dockerfile
+++ b/0.3.1/mingw/Dockerfile
@@ -1,0 +1,110 @@
+FROM archlinux:latest
+
+# Based on https://github.com/haffmans/docker-mingw-qt5/blob/master/Dockerfile
+
+# Update base system
+#RUN    pacman -Sy --noconfirm --noprogressbar archlinux-keyring \
+#    && pacman-key --populate \
+RUN    pacman -Syu --noconfirm --noprogressbar pacman \
+    && pacman-db-upgrade \
+    && pacman -Su --noconfirm --noprogressbar ca-certificates \
+    && trust extract-compat \
+    && pacman -Su --noconfirm --noprogressbar git pyalpm base-devel libffi \
+    && pacman -Syyu --noconfirm --noprogressbar \
+    && (echo -e "y\ny\n" | pacman -Scc)
+
+# Install pikaur
+RUN useradd --create-home --comment "Arch Build User" build && \
+    groupadd sudo && \
+    echo '%sudo ALL=(ALL) NOPASSWD:ALL' >> /etc/sudoers; \
+    echo 'Defaults:nobody !requiretty' >> /etc/sudoers; \
+    gpasswd -a build sudo
+
+RUN chown -R build /home/build
+
+USER build
+# Overrides from arch-base
+ENV HOME /home/build
+
+WORKDIR /home/build/
+RUN git clone https://aur.archlinux.org/pikaur.git
+
+WORKDIR /home/build/pikaur
+RUN makepkg -sr --noconfirm
+
+USER root
+RUN pacman -U pikaur-*.zst --noconfirm && pacman -Scc --noconfirm && rm -r /home/build/*
+
+# Add some useful packages to the base system
+RUN pacman -S --noconfirm --noprogressbar \
+        make \
+        git \
+        sudo \
+        wget \
+        awk \
+        sudo \
+        fakeroot \
+        file \
+        patch \
+        ninja \
+        ccache \
+    && (echo -e "y\ny\n" | pacman -Scc)
+
+# Add ownstuff repo
+# See https://wiki.archlinux.org/index.php/unofficial_user_repositories#ownstuff and https://martchus.no-ip.biz/repoindex/#packages
+RUN    echo "[ownstuff]" >> /etc/pacman.conf \
+    && echo "SigLevel = Optional TrustAll" >> /etc/pacman.conf \
+    && echo "Server = https://ftp.f3l.de/~martchus/\$repo/os/\$arch" >> /etc/pacman.conf \
+    && echo "Server = https://martchus.no-ip.biz/repo/arch/\$repo/os/\$arch" >> /etc/pacman.conf \
+    && pacman -Sy
+
+USER build
+# Install MingW packages
+RUN pikaur -S --noconfirm --noprogressbar \
+        mingw-w64-binutils \
+        mingw-w64-bzip2 \
+        mingw-w64-boost \
+        mingw-w64-cmake \
+        mingw-w64-crt \
+        mingw-w64-curl \
+        mingw-w64-duktape \
+        mingw-w64-fontconfig \
+        mingw-w64-freetype2 \
+        mingw-w64-gcc \
+        mingw-w64-gnutls \
+        mingw-w64-headers \
+        mingw-w64-libiconv \
+        mingw-w64-libpng \
+        mingw-w64-nettle \
+        mingw-w64-openssl \
+        mingw-w64-pkg-config \
+        mingw-w64-sdl2 \
+        mingw-w64-speexdsp \
+        mingw-w64-tools \
+        mingw-w64-winpthreads \
+        mingw-w64-xz \
+        mingw-w64-zlib \
+        pkgconf \
+    && (echo -e "y\ny\n" | sudo pacman -Scc)
+
+WORKDIR /home/build/
+COPY mingw-w64-libzip mingw-w64-libzip
+USER root
+# GMP and Nettle seem to have their mingw libraries misnamed. pkg-config
+# points to .a, not .dll.a files; additionally cmake removes any such
+# extensions, so symlink the files to their expected places
+RUN    ln -s /usr/i686-w64-mingw32/lib/libp11-kit.dll.a /usr/i686-w64-mingw32/lib/libp11-kit.a \
+    && ln -s /usr/i686-w64-mingw32/lib/libgmp.dll.a /usr/i686-w64-mingw32/lib/libgmp.a
+RUN chown -R build /home/build
+USER build
+WORKDIR /home/build/mingw-w64-libzip
+RUN makepkg -sr --noconfirm
+USER root
+RUN pacman -U mingw-w64-libzip-*.zst --noconfirm && pacman -Scc --noconfirm && rm -r /home/build/*
+
+RUN mkdir /usr/i686-w64-mingw32/include/nlohmann /usr/x86_64-w64-mingw32/include/nlohmann
+RUN ls /usr/i686-w64-mingw32/include/nlohmann/
+RUN wget https://github.com/nlohmann/json/releases/download/v3.9.1/json.hpp -O /usr/i686-w64-mingw32/include/nlohmann/json.hpp && cp /usr/i686-w64-mingw32/include/nlohmann/json.hpp /usr/x86_64-w64-mingw32/include/nlohmann/json.hpp
+
+# Bash is required for OpenRCT2 CI
+SHELL ["/bin/bash", "-c"]

--- a/0.3.1/mingw/Dockerfile
+++ b/0.3.1/mingw/Dockerfile
@@ -48,7 +48,7 @@ RUN pacman -S --noconfirm --noprogressbar \
         patch \
         ninja \
         ccache \
-		unzip \
+        unzip \
     && (echo -e "y\ny\n" | pacman -Scc)
 
 # Add ownstuff repo

--- a/0.3.1/mingw/Dockerfile
+++ b/0.3.1/mingw/Dockerfile
@@ -48,6 +48,7 @@ RUN pacman -S --noconfirm --noprogressbar \
         patch \
         ninja \
         ccache \
+		unzip \
     && (echo -e "y\ny\n" | pacman -Scc)
 
 # Add ownstuff repo
@@ -102,9 +103,7 @@ RUN makepkg -sr --noconfirm
 USER root
 RUN pacman -U mingw-w64-libzip-*.zst --noconfirm && pacman -Scc --noconfirm && rm -r /home/build/*
 
-RUN mkdir /usr/i686-w64-mingw32/include/nlohmann /usr/x86_64-w64-mingw32/include/nlohmann
-RUN ls /usr/i686-w64-mingw32/include/nlohmann/
-RUN wget https://github.com/nlohmann/json/releases/download/v3.9.1/json.hpp -O /usr/i686-w64-mingw32/include/nlohmann/json.hpp && cp /usr/i686-w64-mingw32/include/nlohmann/json.hpp /usr/x86_64-w64-mingw32/include/nlohmann/json.hpp
+RUN	wget https://github.com/nlohmann/json/releases/download/v3.9.1/include.zip -O /usr/i686-w64-mingw32/json.zip && unzip /usr/i686-w64-mingw32/json.zip -d /usr/i686-w64-mingw32/ && unzip /usr/i686-w64-mingw32/json.zip -d /usr/x86_64-w64-mingw32/
 
 # Bash is required for OpenRCT2 CI
 SHELL ["/bin/bash", "-c"]

--- a/0.3.1/mingw/mingw-w64-libzip/PKGBUILD
+++ b/0.3.1/mingw/mingw-w64-libzip/PKGBUILD
@@ -1,0 +1,44 @@
+pkgname=mingw-w64-libzip
+pkgver=1.7.3
+pkgrel=1
+pkgdesc="A C library for reading, creating, and modifying zip archives (mingw-w64)"
+url="http://www.nih.at/libzip/index.html"
+license=('BSD')
+arch=(any)
+depends=('mingw-w64-xz' 'mingw-w64-zlib' 'mingw-w64-bzip2' 'mingw-w64-openssl' 'mingw-w64-gnutls')
+makedepends=('mingw-w64-cmake')
+options=('staticlibs' '!buildflags' '!strip')
+source=("http://www.nih.at/libzip/libzip-${pkgver}.tar.xz")
+sha256sums=('a60473ffdb7b4260c08bfa19c2ccea0438edac11193c3afbbb1f17fbcf6c6132')
+
+_architectures="i686-w64-mingw32 x86_64-w64-mingw32"
+
+prepare() {
+  cd "$srcdir/libzip-${pkgver}"
+}
+
+build() {
+  cd "$srcdir/libzip-${pkgver}"
+  for _arch in ${_architectures}; do
+    mkdir -p build-${_arch} && pushd build-${_arch}
+    ${_arch}-cmake -DBUILD_DOC=OFF -DBUILD_EXAMPLES=OFF -DBUILD_REGRESS=OFF -DBUILD_TOOLS=OFF -DENABLE_WINDOWS_CRYPTO=OFF ..
+    make
+    popd
+    mkdir -p build-${_arch}-static && pushd build-${_arch}-static
+    ${_arch}-cmake -DBUILD_DOC=OFF -DBUILD_EXAMPLES=OFF -DBUILD_REGRESS=OFF -DBUILD_TOOLS=OFF -DBUILD_SHARED_LIBS=OFF -DENABLE_WINDOWS_CRYPTO=OFF ..
+    make
+    popd
+  done
+}
+
+package() {
+  for _arch in ${_architectures}; do
+    cd "$srcdir/libzip-${pkgver}/build-$_arch-static"
+    make DESTDIR="${pkgdir}" install
+    cd "$srcdir/libzip-${pkgver}/build-$_arch"
+    make DESTDIR="${pkgdir}" install
+    ${_arch}-strip --strip-unneeded "$pkgdir"/usr/${_arch}/bin/*.dll
+    ${_arch}-strip -g "$pkgdir"/usr/${_arch}/lib/*.a
+  done
+}
+

--- a/README.md
+++ b/README.md
@@ -17,8 +17,14 @@ $ docker run --rm -w /w -v /tmp/openrct2-src:/w -it openrct2/openrct2-build
 
 Distributed builds of OpenRCT2 for Linux are currently built by Ubuntu 18.04.
 
-- [`latest`, `0.3.0`, `0.3.0-bionic` (*0.3.0/bionic/Dockerfile*)](https://github.com/OpenRCT2/openrct2-docker-build/blob/master/0.3.0/bionic/Dockerfile)
+- [`latest`, `0.3.1`, `0.3.1-bionic` (*0.3.1/bionic/Dockerfile*)](https://github.com/OpenRCT2/openrct2-docker-build/blob/master/0.3.1/bionic/Dockerfile)
+- [`0.3.1-bionic32` (*0.3.1/bionic32/Dockerfile*)](https://github.com/OpenRCT2/openrct2-docker-build/blob/master/0.3.1/bionic32/Dockerfile)
+- [`0.3.1-format` (*0.3.1/format/Dockerfile*)](https://github.com/OpenRCT2/openrct2-docker-build/blob/master/0.3.1/format/Dockerfile)
+- [`0.3.1-mingw` (*0.3.1/mingw/Dockerfile*)](https://github.com/OpenRCT2/openrct2-docker-build/blob/master/0.3.1/mingw/Dockerfile)
+- [`0.3.0`, `0.3.0-bionic` (*0.3.0/bionic/Dockerfile*)](https://github.com/OpenRCT2/openrct2-docker-build/blob/master/0.3.0/bionic/Dockerfile)
 - [`0.3.0-bionic32` (*0.3.0/bionic32/Dockerfile*)](https://github.com/OpenRCT2/openrct2-docker-build/blob/master/0.3.0/bionic32/Dockerfile)
+- [`0.3.0-format` (*0.3.0/format/Dockerfile*)](https://github.com/OpenRCT2/openrct2-docker-build/blob/master/0.3.0/format/Dockerfile)
+- [`0.3.0-mingw` (*0.3.0/mingw/Dockerfile*)](https://github.com/OpenRCT2/openrct2-docker-build/blob/master/0.3.0/mingw/Dockerfile)
 - [`0.2.4`, `0.2.4-bionic` (*0.2.4/bionic/Dockerfile*)](https://github.com/OpenRCT2/openrct2-docker-build/blob/master/0.2.4/bionic/Dockerfile)
 - [`0.2.4-bionic32` (*0.2.4/bionic32/Dockerfile*)](https://github.com/OpenRCT2/openrct2-docker-build/blob/master/0.2.4/bionic32/Dockerfile)
 - [`0.2.4-format` (*0.2.4/format/Dockerfile*)](https://github.com/OpenRCT2/openrct2-docker-build/blob/master/0.2.4/format/Dockerfile)


### PR DESCRIPTION
To go along with OpenRCT2/OpenRCT2#13068 that uses `nlohmann/json_fwd.cpp`, which isn't currently downloaded in the docker images.