### PR TITLE
Add Version 20 with zstd

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
       matrix:
         # Remember if you commit this, newly built images will replace those tags.
         # Prefer incrementing the version to unused one
-        tag: [19-android, 19-noble, 19-bookworm, 19-format, 19-mingw, 19-emscripten]
+        tag: [20-android, 20-noble, 20-bookworm, 20-format, 20-mingw, 20-emscripten]
     env:
       dockertag: ${{ matrix.tag }}
     steps:
@@ -39,10 +39,10 @@ jobs:
         run: |
           if [ "$dockerid" != "" ]; then
               docker login -u "$dockerid" -p "$dockerpass"
-              docker pull openrct2/openrct2-build:19-noble
-              docker tag openrct2/openrct2-build:19-noble openrct2/openrct2-build:19
-              docker tag openrct2/openrct2-build:19-noble openrct2/openrct2-build:latest
-              docker push openrct2/openrct2-build:19
+              docker pull openrct2/openrct2-build:20-noble
+              docker tag openrct2/openrct2-build:20-noble openrct2/openrct2-build:20
+              docker tag openrct2/openrct2-build:20-noble openrct2/openrct2-build:latest
+              docker push openrct2/openrct2-build:20
               docker push openrct2/openrct2-build:latest
           else
               echo 'Images not tagged'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,7 @@
 name: CI
 on: [push, pull_request]
 env:
+  dockerns: ${{ vars.dockerns || 'openrct2' }}
   dockerid: ${{ secrets.dockerid }}
   dockerpass: ${{ secrets.dockerpass }}
 jobs:
@@ -21,12 +22,12 @@ jobs:
       - name: Build docker image
         run: |
           ctxpath=${dockertag//-/\/}
-          docker build -t openrct2/openrct2-build:$dockertag $ctxpath
+          docker build -t $dockerns/openrct2-build:$dockertag $ctxpath
       - name: Publish docker image
         run: |
           if [ "$dockerid" != "" ]; then
               docker login -u "$dockerid" -p "$dockerpass"
-              docker push openrct2/openrct2-build:$dockertag
+              docker push $dockerns/openrct2-build:$dockertag
           else
               echo 'Image not pushed'
           fi
@@ -39,11 +40,11 @@ jobs:
         run: |
           if [ "$dockerid" != "" ]; then
               docker login -u "$dockerid" -p "$dockerpass"
-              docker pull openrct2/openrct2-build:20-noble
-              docker tag openrct2/openrct2-build:20-noble openrct2/openrct2-build:20
-              docker tag openrct2/openrct2-build:20-noble openrct2/openrct2-build:latest
-              docker push openrct2/openrct2-build:20
-              docker push openrct2/openrct2-build:latest
+              docker pull $dockerns/openrct2-build:20-noble
+              docker tag $dockerns/openrct2-build:20-noble $dockerns/openrct2-build:20
+              docker tag $dockerns/openrct2-build:20-noble $dockerns/openrct2-build:latest
+              docker push $dockerns/openrct2-build:20
+              docker push $dockerns/openrct2-build:latest
           else
               echo 'Images not tagged'
           fi

--- a/20/android/Dockerfile
+++ b/20/android/Dockerfile
@@ -1,0 +1,50 @@
+# Default image that can build OpenRCT2 for Android.
+FROM ubuntu:24.04
+RUN apt-get update && \
+    apt-get -y upgrade && \
+    DEBIAN_FRONTEND=noninteractive apt-get install --no-install-recommends -y \
+  # System
+    ca-certificates curl unzip \
+  # Build tools
+    git cmake pkg-config ninja-build ccache g++ \
+  # Sprite builder libraries for the host
+    libpng-dev \
+    openjdk-21-jdk
+
+ENV ANDROID_HOME=/android-dev
+ENV ANDROID_NDK_HOME="$ANDROID_HOME/ndk"
+ENV JAVA_HOME=/usr/lib/jvm/java-21-openjdk-amd64
+
+# Grab the Android SDK
+WORKDIR /tmp/setup
+RUN curl -Lo sdk.zip https://dl.google.com/android/repository/commandlinetools-linux-13114758_latest.zip \
+ && unzip -qo sdk.zip \
+ && mkdir -p $ANDROID_HOME/cmdline-tools \
+ && mv cmdline-tools $ANDROID_HOME/cmdline-tools/latest \
+ && rm sdk.zip
+
+# Need nlohmann/json, needs to live outside system libraries, so it doesn't
+# confuse toolchain to include other host headers.
+# 3.12.0 contains a major issue related to utf8 strings. Should be fixed when 3.12.1 releases
+RUN curl -Lo json.zip https://github.com/nlohmann/json/releases/download/v3.11.3/include.zip \
+ && unzip -qo json.zip -d json \
+ && mkdir -p /opt/openrct2/include/ \
+ && mv json/include/nlohmann /opt/openrct2/include/nlohmann \
+ && rm json.zip
+
+# Clean up
+RUN rm -rf /tmp/setup
+WORKDIR /
+
+# Accept SDK licenses
+RUN yes | "$ANDROID_HOME/cmdline-tools/latest/bin/sdkmanager" --licenses > /dev/null
+
+# Install NDK
+RUN "$ANDROID_HOME/cmdline-tools/latest/bin/sdkmanager" "ndk;27.3.13750724"
+RUN "$ANDROID_HOME/cmdline-tools/latest/bin/sdkmanager" "cmake;4.0.3"
+RUN "$ANDROID_HOME/cmdline-tools/latest/bin/sdkmanager" "build-tools;36.0.0"
+RUN "$ANDROID_HOME/cmdline-tools/latest/bin/sdkmanager" "platforms;android-36"
+RUN "$ANDROID_HOME/cmdline-tools/latest/bin/sdkmanager" "platform-tools"
+
+# Bash is required for OpenRCT2 CI
+SHELL ["/bin/bash", "-c"]

--- a/20/bookworm/Dockerfile
+++ b/20/bookworm/Dockerfile
@@ -1,0 +1,22 @@
+# Supplementart image that can build OpenRCT2 for Linux (amd64).
+# Provides building with cmake+ninja using either gcc or clang.
+FROM debian:bookworm
+RUN apt-get update && \
+    apt-get -y upgrade && \
+    DEBIAN_FRONTEND=noninteractive apt-get install --no-install-recommends -y \
+  # System
+    ca-certificates curl file libcairo2 patchelf unzip \
+  # Build tools
+    git cmake pkg-config ninja-build ccache g++ clang \
+  # Build libraries
+    libsdl2-dev libspeex-dev libspeexdsp-dev \
+    libflac-dev libogg-dev libvorbis-dev libopenal-dev \
+    libcrypto++-dev libcurl4-openssl-dev libssl-dev \
+    libfontconfig1-dev libfreetype6-dev \
+    libicu-dev libpng-dev libzip-dev \
+    nlohmann-json3-dev libzstd-dev \
+  # Testing libraries
+    libgtest-dev
+
+# Bash is required for OpenRCT2 CI
+SHELL ["/bin/bash", "-c"]

--- a/20/emscripten/Dockerfile
+++ b/20/emscripten/Dockerfile
@@ -1,0 +1,35 @@
+FROM docker.io/library/fedora:42
+
+RUN dnf update -y && dnf install -y git cmake make gcc g++ nlohmann-json-devel autoreconf libtool openssl-devel libcurl-devel fontconfig-devel libzip-devel SDL2-devel zip speexdsp-devel ninja-build hostname ccache libatomic
+
+WORKDIR /
+
+RUN git clone https://github.com/emscripten-core/emsdk.git
+
+WORKDIR /emsdk/
+
+# Pin version - to prevent sudden breakage of the CI
+RUN ./emsdk install 4.0.11
+RUN ./emsdk activate 4.0.11
+
+# "Install" json headers to emscripten include directory
+RUN cp -r /usr/include/nlohmann /emsdk/upstream/emscripten/cache/sysroot/include/nlohmann
+
+# Add emscripten to path
+ENV PATH="/emsdk:/emsdk/upstream/emscripten:/emsdk/node/22.16.0_64bit/bin:$PATH"
+
+WORKDIR /ext/
+
+COPY build-depends.sh /ext/
+COPY cors_serve.py /usr/bin/
+
+# Build emscripten dependencies
+RUN bash build-depends.sh
+
+# Set ENV variables for speexdsp, icu, and libzip
+ENV SPEEXDSP_ROOT="/ext/speexdsp"
+ENV ICU_ROOT="/ext/icu/icu4c/source"
+ENV LIBZIP_ROOT="/ext/libzip/build"
+
+
+SHELL ["/bin/bash", "-c"]

--- a/20/emscripten/build-depends.sh
+++ b/20/emscripten/build-depends.sh
@@ -1,0 +1,67 @@
+#!/bin/bash
+
+START_DIR=/ext
+
+cd $START_DIR
+
+# Pin versions - to prevent sudden breakage
+if [ ! -d "speexdsp" ]; then
+    git clone https://gitlab.xiph.org/xiph/speexdsp.git --depth 1 --branch SpeexDSP-1.2.1
+fi
+if [ ! -d "icu" ]; then
+    git clone https://github.com/unicode-org/icu.git --depth 1 --branch release-77-1
+fi
+if [ ! -d "libzip" ]; then
+    git clone https://github.com/nih-at/libzip.git --depth 1 --branch v1.11.4
+fi
+if [ ! -d "zlib" ]; then
+    git clone https://github.com/madler/zlib.git --depth 1 --branch v1.3.1
+fi
+if [ ! -d "zstd" ]; then
+    git clone https://github.com/facebook/zstd.git --depth 1 --branch v1.5.7
+fi
+
+cd speexdsp
+emmake ./autogen.sh
+emmake ./configure --enable-shared --disable-neon
+emmake make -j$(nproc)
+cd $START_DIR
+
+cd icu/icu4c/source
+ac_cv_namespace_ok=yes icu_cv_host_frag=mh-linux emmake ./configure \
+    --enable-release \
+    --enable-shared \
+    --disable-icu-config \
+    --disable-extras \
+    --disable-icuio \
+    --disable-layoutex \
+    --disable-tools \
+    --disable-tests \
+    --disable-samples
+emmake make -j$(nproc)
+cd $START_DIR
+
+cd zlib
+mkdir -p build/
+cd build/
+emcmake cmake ../
+emmake make zlib -j$(nproc)
+emmake make install
+ZLIB_ROOT=$(pwd)
+cd $START_DIR
+
+cd libzip
+mkdir -p build/
+cd build/
+emcmake cmake ../ -DZLIB_INCLUDE_DIR="$ZLIB_ROOT" -DZLIB_LIBRARY="$ZLIB_ROOT/libz.a"
+emmake make zip -j$(nproc)
+emmake make install
+cd $START_DIR
+
+cd zstd
+mkdir -p build/build/
+cd build/build/
+emcmake cmake ../cmake/ -DZSTD_BUILD_STATIC=ON -DZSTD_BUILD_SHARED=OFF -DZSTD_BUILD_PROGRAMS=OFF
+emmake make -j$(nproc)
+emmake make install
+cd $START_DIR

--- a/20/emscripten/cors_serve.py
+++ b/20/emscripten/cors_serve.py
@@ -1,0 +1,15 @@
+#!/usr/bin/env python3
+from http.server import HTTPServer, SimpleHTTPRequestHandler, test
+import sys
+
+class CORSRequestHandler (SimpleHTTPRequestHandler):
+    def end_headers (self):
+        self.send_header('Cross-Origin-Embedder-Policy', 'require-corp')
+        self.send_header('Cross-Origin-Opener-Policy', 'same-origin')
+        SimpleHTTPRequestHandler.end_headers(self)
+
+def main():
+    test(CORSRequestHandler, HTTPServer, port=int(sys.argv[1]) if len(sys.argv) > 1 else 8000)
+
+if __name__ == '__main__':
+    main()

--- a/20/format/Dockerfile
+++ b/20/format/Dockerfile
@@ -1,0 +1,3 @@
+# Image specifically designed to run clang-format on OpenRCT2 source files.
+FROM alpine
+RUN apk add --no-cache python3 clang20-extra-tools

--- a/20/mingw/Dockerfile
+++ b/20/mingw/Dockerfile
@@ -1,0 +1,113 @@
+FROM archlinux:latest
+
+# Based on https://github.com/haffmans/docker-mingw-qt5/blob/master/Dockerfile
+
+# Update base system
+#RUN    pacman -Sy --noconfirm --noprogressbar archlinux-keyring \
+#    && pacman-key --populate \
+RUN    pacman -Syu --noconfirm --noprogressbar pacman \
+    && pacman-db-upgrade \
+    && pacman -Su --noconfirm --noprogressbar ca-certificates \
+    && trust extract-compat \
+    && pacman -Su --noconfirm --noprogressbar git pyalpm base-devel libffi \
+    && pacman -Syyu --noconfirm --noprogressbar \
+    && (echo -e "y\ny\n" | pacman -Scc)
+
+# Install pikaur
+RUN useradd --create-home --comment "Arch Build User" build && \
+    groupadd sudo && \
+    echo '%sudo ALL=(ALL) NOPASSWD:ALL' >> /etc/sudoers; \
+    echo 'Defaults:nobody !requiretty' >> /etc/sudoers; \
+    gpasswd -a build sudo
+
+RUN chown -R build /home/build
+
+USER build
+# Overrides from arch-base
+ENV HOME /home/build
+
+WORKDIR /home/build/
+RUN git clone https://aur.archlinux.org/pikaur.git
+
+WORKDIR /home/build/pikaur
+RUN makepkg -sr --noconfirm
+
+USER root
+RUN pacman -U pikaur-*.zst --noconfirm && pacman -Scc --noconfirm && rm -r /home/build/*
+
+# Add some useful packages to the base system
+RUN pacman -S --noconfirm --noprogressbar \
+        make \
+        git \
+        sudo \
+        wget \
+        awk \
+        sudo \
+        fakeroot \
+        file \
+        patch \
+        ninja \
+        ccache \
+        unzip \
+    && (echo -e "y\ny\n" | pacman -Scc)
+
+# Add ownstuff repo
+# See https://wiki.archlinux.org/index.php/unofficial_user_repositories#ownstuff and https://martchus.no-ip.biz/repoindex/#packages
+RUN    echo "[ownstuff]" >> /etc/pacman.conf \
+    && echo "SigLevel = Optional TrustAll" >> /etc/pacman.conf \
+    && echo "Server = https://ftp.f3l.de/~martchus/\$repo/os/\$arch" >> /etc/pacman.conf \
+    && echo "Server = https://martchus.no-ip.biz/repo/arch/\$repo/os/\$arch" >> /etc/pacman.conf \
+    && pacman -Sy
+
+USER build
+# Install MingW packages
+RUN pikaur -S --noconfirm --noprogressbar \
+        mingw-w64-binutils \
+        mingw-w64-bzip2 \
+        mingw-w64-boost \
+        mingw-w64-cmake \
+        mingw-w64-crt \
+        mingw-w64-curl \
+        mingw-w64-flac \
+        mingw-w64-fontconfig \
+        mingw-w64-freetype2 \
+        mingw-w64-gcc \
+        mingw-w64-gnutls \
+        mingw-w64-headers \
+        mingw-w64-libiconv \
+        mingw-w64-libogg \
+        mingw-w64-libpng \
+        mingw-w64-libvorbis \
+        mingw-w64-nettle \
+        mingw-w64-openal \
+        mingw-w64-openssl \
+        mingw-w64-pkg-config \
+        mingw-w64-sdl2 \
+        mingw-w64-speexdsp \
+        mingw-w64-tools \
+        mingw-w64-winpthreads \
+        mingw-w64-xz \
+        mingw-w64-zlib \
+        mingw-w64-zstd \
+        pkgconf \
+    && (echo -e "y\ny\n" | sudo pacman -Scc)
+
+WORKDIR /home/build/
+COPY mingw-w64-libzip mingw-w64-libzip
+USER root
+# GMP and Nettle seem to have their mingw libraries misnamed. pkg-config
+# points to .a, not .dll.a files; additionally cmake removes any such
+# extensions, so symlink the files to their expected places
+RUN    ln -s /usr/i686-w64-mingw32/lib/libp11-kit.dll.a /usr/i686-w64-mingw32/lib/libp11-kit.a \
+    && ln -s /usr/i686-w64-mingw32/lib/libgmp.dll.a /usr/i686-w64-mingw32/lib/libgmp.a
+RUN chown -R build /home/build
+USER build
+WORKDIR /home/build/mingw-w64-libzip
+RUN makepkg -sr --noconfirm
+USER root
+RUN pacman -U mingw-w64-libzip-*.zst --noconfirm && pacman -Scc --noconfirm && rm -r /home/build/*
+
+RUN	wget https://github.com/nlohmann/json/releases/download/v3.11.3/include.zip -O /usr/i686-w64-mingw32/json.zip && unzip /usr/i686-w64-mingw32/json.zip -d /usr/i686-w64-mingw32/ && unzip /usr/i686-w64-mingw32/json.zip -d /usr/x86_64-w64-mingw32/
+
+# Bash is required for OpenRCT2 CI
+SHELL ["/bin/bash", "-c"]

--- a/20/mingw/mingw-w64-libzip/PKGBUILD
+++ b/20/mingw/mingw-w64-libzip/PKGBUILD
@@ -1,0 +1,48 @@
+# Maintainer: Vaporeon <vaporeon@vaporeon.io>
+# Contributor: xantares
+
+pkgname=mingw-w64-libzip
+pkgver=1.11.4
+pkgrel=1
+pkgdesc="A C library for reading, creating, and modifying zip archives (mingw-w64)"
+url="http://www.nih.at/libzip/index.html"
+license=('BSD')
+arch=(any)
+depends=('mingw-w64-xz' 'mingw-w64-zlib' 'mingw-w64-bzip2' 'mingw-w64-openssl' 'mingw-w64-gnutls')
+makedepends=('mingw-w64-cmake' 'ninja')
+options=('staticlibs' '!buildflags' '!strip')
+source=("http://www.nih.at/libzip/libzip-${pkgver}.tar.xz")
+sha256sums=('8a247f57d1e3e6f6d11413b12a6f28a9d388de110adc0ec608d893180ed7097b')
+
+_architectures="i686-w64-mingw32 x86_64-w64-mingw32"
+_pkgname="libzip"
+
+build() {
+  for _arch in ${_architectures}; do
+    ${_arch}-cmake -S ${_pkgname}-${pkgver} -B build/${_arch}-static -G Ninja \
+      -DBUILD_DOC=OFF \
+      -DBUILD_EXAMPLES=OFF \
+      -DBUILD_REGRESS=OFF \
+      -DBUILD_TOOLS=OFF \
+      -DBUILD_SHARED_LIBS=OFF
+
+    ${_arch}-cmake -S ${_pkgname}-${pkgver} -B build/${_arch} -G Ninja \
+      -DBUILD_DOC=OFF \
+      -DBUILD_EXAMPLES=OFF \
+      -DBUILD_REGRESS=OFF \
+      -DBUILD_TOOLS=OFF
+
+    cmake --build build/${_arch}-static
+    cmake --build build/${_arch}
+  done
+}
+
+package() {
+  for _arch in ${_architectures}; do
+    DESTDIR="${pkgdir}" cmake --install build/${_arch}-static
+    DESTDIR="${pkgdir}" cmake --install build/${_arch}
+    ${_arch}-strip --strip-unneeded "${pkgdir}"/usr/${_arch}/bin/*.dll
+    ${_arch}-strip -g "${pkgdir}"/usr/${_arch}/lib/*.a
+  done
+}
+

--- a/20/noble/Dockerfile
+++ b/20/noble/Dockerfile
@@ -1,0 +1,22 @@
+# Default image that can build OpenRCT2 for Linux (amd64).
+# Provides building with cmake+ninja using either gcc or clang.
+FROM ubuntu:24.04
+RUN apt-get update && \
+    apt-get -y upgrade && \
+    DEBIAN_FRONTEND=noninteractive apt-get install --no-install-recommends -y \
+  # System
+    ca-certificates curl file libcairo2 patchelf unzip \
+  # Build tools
+    git cmake pkg-config ninja-build ccache g++ clang clang-tidy libclang-rt-dev llvm \
+  # Build libraries
+    libsdl2-dev libspeex-dev libspeexdsp-dev xz-utils \
+    libflac-dev libogg-dev libvorbis-dev libopenal-dev \
+    libcrypto++-dev libcurl4-openssl-dev libssl-dev \
+    libfontconfig1-dev libfreetype6-dev \
+    libicu-dev libpng-dev libzip-dev \
+    nlohmann-json3-dev libzstd-dev \
+  # Testing libraries
+    libgtest-dev
+
+# Bash is required for OpenRCT2 CI
+SHELL ["/bin/bash", "-c"]


### PR DESCRIPTION
This is a PR to add the zstd dependency for https://github.com/OpenRCT2/OpenRCT2/pull/24734.

While I was in here, I updated various libraries and tools (eg. Emscripten) as part of the release. Since these are significant updates, I pumped the version number from 19 to 20 to avoid overwriting the old version. This should include all the changes needed for https://github.com/OpenRCT2/OpenRCT2/pull/24843 as well.

For testing with the CI, I wanted to be able to use the github workflow to push the images to my own docker.io account, but the workflow as written didn't support that. I made some changes to the script to allow for forks to push to their own accounts like I did. I made the assumption that `secrets.dockerid` is just the public account name 'openrct2'. If that assumption is wrong, then I can adjust the script to account for that. It also can be changed to be a public variable in that case, but for simplicity, I kept it as a secret.